### PR TITLE
Update medical example notebook with correct argmax equation

### DIFF
--- a/intro_to_inference/medical_example.ipynb
+++ b/intro_to_inference/medical_example.ipynb
@@ -264,7 +264,7 @@
     "3. Select the optimal action $t^{\\star}$ with the largest expected reward\n",
     "\n",
     "\\begin{align}\n",
-    "t^{\\star} = \\underset{t}{\\mathrm{arg\\,min}} \\; R(t) \n",
+    "t^{\\star} = \\underset{t}{\\mathrm{arg\\,max}} \\; R(t) \n",
     "\\end{align}\n",
     "\n",
     "The posterior can be reused for any decision that you need to make until new observations are made."


### PR DESCRIPTION
In the medical example notebook there was the following summary:

---

Bayesian decision theory provides a framework for decision making under uncertainty:

1. First compute the posterior distribution over the unknown state of the world $a$ given evidence $b=1$.

2. Compute the expected reward for each action $t$ (the conditional reward)
$R(t) = \sum_{a} R(a,t) p(a|b=1)$

3. Select the optimal action $t^{\star}$ with the largest expected reward
$t^{\star} = \underset{t}{\mathrm{arg\,min}} \; R(t)$
**! This argmin appears to be incorrect - should be argmax not argmin as the action with the largest reward should be chosen !**
---

I have put forward a simple PR updating this to an argmax 

$t^{\star} = \underset{t}{\mathrm{arg\,max}} \; R(t)$